### PR TITLE
Make the instructions work for `go-ts-mode` users too.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ Installation using [straight.el](https://github.com/radian-software/straight.el)
   :elpaca (flymake-golangci :host github :repo "storvik/flymake-golangci")             ;; using elpaca
   :straight (flymake-golangci :type git :host github :repo "storvik/flymake-golangci") ;; using straight
   :hook ((eglot-managed-mode . (lambda ()
-                                (when (derived-mode-p 'go-mode)
+                                (when (derived-mode-p '(go-mode go-ts-mode))
                                   (flymake-golangci-load-backend)))) ;; using flymake-golangci with eglot
-         (go-mode . flymake-golangci-load-backend)))                 ;; using flymake-golangci with go-mode
+         (go-mode . flymake-golangci-load-backend)                   ;; using flymake-golangci with go-mode
+		 (go-ts-mode . flymake-golangci-load-backend)))              ;; using flymake-golangci with go-ts-mode
 ```
 
 Note that this config does not enable `flymake` or `eldoc` automatically.


### PR DESCRIPTION
## 🗒 Description

In the Brave New World of tree sitter modes, there's a new `go-ts-mode`, which isn't a derived mode of `go-mode`.

## ☑ Checks
- [x] My pull request adheres to the code style of this project
- [-] My code requires changes to the documentation
- [x] I have updated the documentation as required
- [-] All the tests have passed
