### PR TITLE
Fix additional dash required to be able to package-install-file

### DIFF
--- a/flymake-golangci.el
+++ b/flymake-golangci.el
@@ -1,4 +1,4 @@
-;;; flymake-golangci.el -- Flymake checker for golangci linter -*- lexical-binding: t -*-
+;;; flymake-golangci.el --- Flymake checker for golangci linter -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2024 Petter Storvik
 


### PR DESCRIPTION

## 🗒 Description
Add posibility to install package source from a file via `package-install-file`.

According to [library headers convention](https://www.gnu.org/software/emacs/manual/html_node/elisp/Library-Headers.html), the package header must include three dashes instead of two. This fix allow you to install the package via `package-install-file` command. Attempting to install the package before this change leads to "Package lacks a file header file" error.